### PR TITLE
【新增，提案】给 WeDot 编写贡献者文档

### DIFF
--- a/src/index.md
+++ b/src/index.md
@@ -1,3 +1,4 @@
 # To-Do 列表
 
+- [ ] [完善 CONTRIBUTING.md](完善%20CONTRIBUTING.md/index.md)
 - [X] [创建 To-Do 仓库](创建%20To-Do%20仓库/index.md)

--- a/src/完善 CONTRIBUTING.md/index.md
+++ b/src/完善 CONTRIBUTING.md/index.md
@@ -1,0 +1,5 @@
+# 完善 CONTRIBUTING.md
+
+`Wedot-Engine/WeDot` 需要一个社区贡献指南指导提交者。
+
+可参考 [CONTRIBUTING.md](https://github.com/Wedot-Engine/To-Do/blob/main/CONTRIBUTING.md/)。


### PR DESCRIPTION
`Wedot-Engine/WeDot` 需要一个社区贡献指南指导提交者。

可参考 [CONTRIBUTING.md](https://github.com/Wedot-Engine/To-Do/blob/main/CONTRIBUTING.md/)。